### PR TITLE
Update Maven POM for newer javadoc plugins so verify goal runs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
 				</plugin>
 				<plugin>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>2.9.1</version>
+					<version>2.10.3</version>
 				</plugin>
 				<plugin>
 					<artifactId>maven-release-plugin</artifactId>
@@ -214,6 +214,11 @@
 						</lifecycleMappingMetadata>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-gpg-plugin</artifactId>
+					<version>1.6</version>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -258,6 +263,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<configuration>
 					<detectLinks>true</detectLinks>
+                    <failOnError>false</failOnError>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Updated maven-javadoc-plugin to 2.10.3 avoid an "Unable to find javadoc command error" and added failOnError true config so overly pedantic messages about paramters javadocs didn't fail the build.
