### PR TITLE
Minor cleanups

### DIFF
--- a/src/main/java/org/rabinfingerprint/datastructures/Interval.java
+++ b/src/main/java/org/rabinfingerprint/datastructures/Interval.java
@@ -116,7 +116,7 @@ public class Interval implements Comparable<Interval> {
 	 * Tests whether this is an empty (a.k.a. zero-length) interval
 	 */
 	public boolean isEmpty() {
-		return start == end;
+		return start.equals(end);
 	}
 
 	/**

--- a/src/main/java/org/rabinfingerprint/polynomial/Polynomial.java
+++ b/src/main/java/org/rabinfingerprint/polynomial/Polynomial.java
@@ -371,7 +371,7 @@ public class Polynomial implements Arithmetic< Polynomial >, Comparable< Polynom
 			for (BigInteger i = BigInteger.ONE; i.compareTo(degree) <= 0; i = i.add(BigInteger.ONE)) {
 				term = term.shiftLeft(1);
 			}
-			b.add(term);
+			b = b.add(term);
 		}
 		return b;
 	}

--- a/src/main/java/org/rabinfingerprint/scanner/FileFinder.java
+++ b/src/main/java/org/rabinfingerprint/scanner/FileFinder.java
@@ -15,13 +15,16 @@ public class FileFinder {
 		if (!directory.isDirectory()) directory = directory.getParentFile();
 		if (!directory.getName().matches(directoryPattern)) return;
 		visitor.visitDirectory(directory);
-		final ArrayList<File> childDirectories = new ArrayList<File>();
-		for (File file : directory.listFiles()) {
-			if (file.isDirectory()) {
-				childDirectories.add(file);
-			} else if (file.isFile()) {
-				if (!file.getName().matches(filePattern)) continue;
-				visitor.visitFile(file);
+		final ArrayList<File> childDirectories = new ArrayList<File>();		
+		File[] files = directory.listFiles();
+		if(files != null) {
+			for (File file : files) {
+				if (file.isDirectory()) {
+					childDirectories.add(file);
+				} else if (file.isFile()) {
+					if (!file.getName().matches(filePattern)) continue;
+					visitor.visitFile(file);
+				}
 			}
 		}
 		if (recursively) {
@@ -36,9 +39,12 @@ public class FileFinder {
 		if (!directory.getName().matches(pattern)) return;
 		visitor.visitDirectory(directory);
 		final ArrayList<File> childDirectories = new ArrayList<File>();
-		for (File file : directory.listFiles()) {
-			if (file.isDirectory()) {
-				childDirectories.add(file);
+		File[] files = directory.listFiles();
+		if(files != null) {
+			for (File file : files) {
+				if (file.isDirectory()) {
+					childDirectories.add(file);
+				}
 			}
 		}
 		if (recursively) {

--- a/src/main/java/org/rabinfingerprint/scanner/FileListing.java
+++ b/src/main/java/org/rabinfingerprint/scanner/FileListing.java
@@ -10,13 +10,16 @@ public class FileListing {
 
 	public static List<File> getFileListing( File directory ) throws FileNotFoundException {
 		// get files
-		ArrayList<File> files = new ArrayList<File>( Arrays.<File>asList( directory.listFiles() ) );
-		ArrayList<File> result = new ArrayList<File>( files );
+		File[] files = directory.listFiles();
+		ArrayList<File> result = new ArrayList<File>();
+		if( files != null ){		
+			result.addAll( Arrays.<File>asList( files ) );
 
-		// recurse
-		for ( File file : files ) {
-			if ( !file.isDirectory() ) continue;
-			result.addAll( getFileListing( file ) );
+			// recurse
+			for ( File file : files ) {
+				if ( !file.isDirectory() ) continue;
+				result.addAll( getFileListing( file ) );
+			}
 		}
 
 		// return


### PR DESCRIPTION
- Interval.isEmpty compares references to Long instead of actual values

- Polynomial.toBigIntegerAccurate forgets to assign the result of an addition (the method is probably never used, but nevertheless)

- In FileFinder and FileListing although the directly is always a directory, it is still better to do a null check to make SCA tools happy when they analyze this code.  File.listFiles()'s contract is that it may return null.